### PR TITLE
Change api_token config type to password to prevent from leaks in debug logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.7
+  - Change `api_token` config type to `password` to prevent from leaks in debug logs [#7](https://github.com/logstash-plugins/logstash-output-circonus/pull/7)
+
 ## 3.0.6
   - Fix formatting in doc for conversion to --asciidoctor [#5](https://github.com/logstash-plugins/logstash-output-circonus/pull/5)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -33,7 +33,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-annotation>> |<<hash,hash>>|Yes
-| <<plugins-{type}s-{plugin}-api_token>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-api_token>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-app_name>> |<<string,string>>|Yes
 |=======================================================================
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -73,7 +73,7 @@ or
 ===== `api_token` 
 
   * This is a required setting.
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 Your Circonus API Token

--- a/lib/logstash/outputs/circonus.rb
+++ b/lib/logstash/outputs/circonus.rb
@@ -12,7 +12,7 @@ class LogStash::Outputs::Circonus < LogStash::Outputs::Base
   config_name "circonus"
 
   # Your Circonus API Token
-  config :api_token, :validate => :string, :required => true
+  config :api_token, :validate => :password, :required => true
 
   # Your Circonus App name
   # This will be passed through `event.sprintf`
@@ -68,7 +68,7 @@ class LogStash::Outputs::Circonus < LogStash::Outputs::Base
     begin
       request.set_form_data(:annotations => LogStash::Json.dump(annotation_array))
       @logger.warn(annotation_event)
-      request.add_field("X-Circonus-Auth-Token", "#{@api_token}")
+      request.add_field("X-Circonus-Auth-Token", "#{@api_token.value}")
       request.add_field("X-Circonus-App-Name", "#{event.sprintf(@app_name)}")
       response = @client.request(request)
       @logger.warn("Circonus convo", :request => request.inspect, :response => response.inspect)

--- a/logstash-output-circonus.gemspec
+++ b/logstash-output-circonus.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-circonus'
-  s.version         = '3.0.6'
+  s.version         = '3.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends annotations to Circonus based on Logstash events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/circonus_spec.rb
+++ b/spec/outputs/circonus_spec.rb
@@ -1,1 +1,19 @@
 require "logstash/devutils/rspec/spec_helper"
+require 'logstash/outputs/circonus'
+
+describe LogStash::Outputs::Circonus do
+
+  let(:plugin) { described_class.new(config) }
+
+  describe "debugging `api_token`" do
+    let(:config) {{ "app_name" => "my-app-name", "api_token" => "$ecre&-key" }}
+
+    it "should not show origin value" do
+      expect(plugin.logger).to receive(:debug).with('<password>')
+
+      plugin.register
+      plugin.logger.send(:debug, plugin.api_token.to_s)
+    end
+  end
+
+end


### PR DESCRIPTION
When running Logstash with `--config.debug`, `api_token` config value can be seen in the debug logs. This PR changes config's type to `password` to prevent from leaks.

- Closes #6 